### PR TITLE
Updates transcription model to point at whisper instead of whisper-1

### DIFF
--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -21,7 +21,7 @@ export const actions = {
     const buf = Buffer.from(await audio.arrayBuffer());
     const stream = await toFile(buf);
 
-    const text = await openai.audio.transcriptions.create({ model: "whisper-1", file: stream }).then((res) => {
+    const text = await openai.audio.transcriptions.create({ model: "whisper", file: stream }).then((res) => {
       return res.text;
     });
 

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -41,3 +41,4 @@ components:
                 name: doug-translate
                 namespace: doug-translate
                 condition: Available
+


### PR DESCRIPTION
* LeapfrogAI has been updated to use whisper for all its references instead of whisper-1